### PR TITLE
Update CDN references to https.  

### DIFF
--- a/asteroids/index.html
+++ b/asteroids/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.3/jquery.min.js"></script>
-	<script type="text/javascript" src="http://craftyjs.com/release/0.6.3/crafty-min.js"></script>
+	<script type="text/javascript" src="https://craftyjs.com/release/0.6.3/crafty-min.js"></script>
 	<script type="text/javascript" src="game.js"></script>
 	<title>Asteroids</title>
 	<style>

--- a/connect4/index.html
+++ b/connect4/index.html
@@ -2,7 +2,7 @@
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<script type="text/javascript" src="http://craftyjs.com/release/0.6.1/crafty-min.js"></script>
+	<script type="text/javascript" src="https://craftyjs.com/release/0.6.1/crafty-min.js"></script>
 	<script type="text/javascript" src="connect4.js"></script>
 	<title>Connect 4</title>
 	<style>

--- a/fruitassassin/index.html
+++ b/fruitassassin/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html5>
 <html>
 <head>
-	<script src="http://craftyjs.com/release/0.6.1/crafty-min.js" type="text/javascript"></script>
+	<script src="https://craftyjs.com/release/0.6.1/crafty-min.js" type="text/javascript"></script>
 	<script src="assassin.js" type="text/javascript"></script>
 	<style>
 	body { font-family:Verdana; color:#eee; font-weight:bold; text-shadow:1px 1px 1px #000 }


### PR DESCRIPTION
As written, these demos generally fail in recent browsers that do not allow mixed-content references.